### PR TITLE
Wrap dispatchr-module with validation and promises for integration in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ server.pack.register( [
 
 This sends a request down to the dispatchr-module's publish function, which publishes a request to the Dispatchr email queue. 
 
-The Disapcthr service runs as a separate service and will pick up the request when ready to send an email.
+The Dispatchr service runs as a separate service and will pick up the request when ready to send an email.
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,44 @@ server.pack.register( [
 } );
 ```
 
-#### Function: makeItSo
+#### Function: publishEmail
 
-To be written....
+This sends a request down to the dispatchr-module's publish function, which publishes a request to the Dispatchr email queue. 
+
+The Disapcthr service runs as a separate service and will pick up the request when ready to send an email.
+
+Example usage:
+
+```
+var options = {
+	type: 'confirmation',
+	subject: 'Booking Confirmation - MR TEST - 5ABCDEF',
+	to: {
+		name: 'Customer Name',
+		email: 'customer@name.com'
+	},
+	from: {
+		name: 'Paultons Breaks',
+		email: 'do_not_reply@holidayextras.com'
+	},
+	body: {
+		html: {
+			location: 'https://example.com/confirmation.html'
+		},
+		text: {
+			location: 'https://example.com/confirmation.txt'
+		}
+	},
+	bcc: [
+		{
+			name: 'HX Vouchers',
+			email: 'vouchers2@holidayextras.com'
+		}
+	]
+};
+return request.server.plugins['plugin-dispatchr'].publishEmail( options );
+
+```
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,3 @@
-/* jslint node: true */
 'use strict';
 
-/*
-* @name /index.js
-* @description Node style library inclusion
-* @since Mon Jun 02 2014
-* @author Kevin Hodges <kevin.hodges@holidayextras.com>
-*/
-
-module.exports = require( './lib/pluginHttp.js' );
+module.exports = require( './lib/pluginDispatchr.js' );

--- a/lib/defaultOptions.json
+++ b/lib/defaultOptions.json
@@ -1,0 +1,7 @@
+{
+ "client": "WORKS",
+ "timezone": "UTC",
+ "archive": false,
+ "retries": 5,
+ "delay": 0
+}

--- a/lib/pluginDispatchr.js
+++ b/lib/pluginDispatchr.js
@@ -1,4 +1,8 @@
 'use strict';
+var dispatchr = require( 'dispatchr-module' );
+var _ = require( 'lodash' );
+var Q = require( 'q' );
+var defaultOptions = require( './defaultOptions' );
 
 function buildReject( error, context ) {
   return {
@@ -10,13 +14,52 @@ function buildReject( error, context ) {
 
 exports.register = function( server, registerOptions, next ) {
 
+  function _getValidationErrors( options, validator ) {
 
-  function makeItSo( options ) {
-    buildReject( 'some error', options );
+    var validatorErrors = [];
 
+    // loop over each key in the validator and ensure its in the data object and the value matches the validator function
+    _.forEach( validator, function( validatorFunction, key ) {
+
+      if ( _.isUndefined( options[key] ) || !validatorFunction( options[key] ) ) {
+        validatorErrors.push( 'options.' + key );
+      }
+    } );
+
+    return validatorErrors;
   }
 
-  server.expose( 'makeItSo', makeItSo );
+  function publishEmail( options ) {
+
+    var validator = {
+      type: _.isString,
+      subject: _.isString,
+      to: _.isObject,
+      from: _.isObject,
+      body: _.isObject
+    };
+
+    // If there are any errors then pump them all out together as one String.
+    var validatorErrors = _getValidationErrors( options, validator );
+    if ( validatorErrors.length ) {
+      return Q.reject( buildReject( new TypeError( 'invalid ' + validatorErrors.join( ' ' ) ), options ) );
+    }
+
+    // merge a clone of the default options with the passed in options
+    options = _.assign( _.clone( defaultOptions ), options );
+
+    var deferred = Q.defer();
+
+    dispatchr.publish( 'email', options, function( error ) {
+      if ( error ) {
+        deferred.reject( buildReject( error ) );
+      }
+      deferred.resolve();
+    } );
+
+    return deferred.promise;
+  }
+  server.expose( 'publishEmail', publishEmail );
   next();
 };
 

--- a/lib/pluginDispatchr.js
+++ b/lib/pluginDispatchr.js
@@ -45,7 +45,7 @@ exports.register = function( server, registerOptions, next ) {
       return Q.reject( buildReject( new TypeError( 'invalid ' + validatorErrors.join( ' ' ) ), options ) );
     }
 
-    // merge a clone of the default options with the passed in options
+    // Clone the default options and then overwrite them with any passed in options for this request.
     options = _.assign( _.clone( defaultOptions ), options );
 
     var deferred = Q.defer();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "shortbreaksdev@holidayextras.com"
   },
   "repository": {
-    "type": "git",  
+    "type": "git",
     "url": "git@github.com:holidayextras/plugin-dispatchr.git"
   },
   "license": "MIT",
@@ -22,7 +22,6 @@
   "devDependencies": {
     "chai": "1.9.1",
     "chai-as-promised": "4.3.0",
-    "dispatchr-module": "git+ssh://git@github.com:holidayextras/dispatchr-module.git#v1.0.0",
     "hapi": "6.0.2",
     "istanbul": "0.3.7",
     "make-up": "5.3.1",
@@ -31,8 +30,8 @@
     "sinon": "1.12.2"
   },
   "dependencies": {
+    "dispatchr-module": "git+ssh://git@github.com:holidayextras/dispatchr-module.git#v1.0.0",
     "lodash": "2.4.1",
-    "qs": "0.6.6",
-    "q": "1.0.1"
+    "q": "1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,11 @@
     "istanbul": "0.3.7",
     "make-up": "5.3.1",
     "mocha": "1.20.1",
-    "nock": "1.6.0",
     "sinon": "1.12.2"
   },
   "dependencies": {
     "dispatchr-module": "git+ssh://git@github.com:holidayextras/dispatchr-module.git#v1.0.0",
-    "lodash": "2.4.1",
+    "lodash": "3.10.1",
     "q": "1.4.1"
   }
 }

--- a/results.xml
+++ b/results.xml
@@ -1,0 +1,13 @@
+<testsuite name="Mocha Tests" tests="4" failures="0" errors="0" skipped="0" timestamp="Wed, 16 Sep 2015 14:25:29 GMT" time="0.046">
+<testcase classname="pluginDispatchr #register" name="should allow us to access the plugin off the hapi server" time="0"/>
+<testcase classname="pluginDispatchr #publishEmail Validation" name="should fail when the options are missing required parameters" time="0.002"/>
+<testcase classname="pluginDispatchr #publishEmail Dispatchr module successful" name="should be call dispatchr-module with the correct parameters and resolve" time="0.002"/>
+<testcase classname="pluginDispatchr #publishEmail Dispatchr module errorred" name="should pass back errors from dispatchr-module as a rejected promise" time="0"/>
+</testsuite>
+
+=============================== Coverage summary ===============================
+Statements   : 100% ( 29/29 )
+Branches     : 100% ( 8/8 )
+Functions    : 100% ( 7/7 )
+Lines        : 100% ( 29/29 )
+================================================================================

--- a/shippable.yml
+++ b/shippable.yml
@@ -15,8 +15,7 @@ before_script:
 # Running the tests with npm
 script:
   - node_modules/.bin/make-up lib test
-  - istanbul cover _mocha -- --recursive -R xunit > shippable/testresults/results.xml
-  - istanbul report cobertura --dir  shippable/codecoverage/
+  - istanbul cover _mocha -- --recursive -R xunit
 
 # Setup our environment with the IAM credentials
 # we're using IAM user "shippable"

--- a/test/expected/validMergedOptions.json
+++ b/test/expected/validMergedOptions.json
@@ -1,0 +1,25 @@
+{
+  "archive": false,
+  "body": {
+    "html": {
+      "location": "https://example.com"
+    },
+    "text": {
+      "location": "https://example.com"
+    }
+  },
+  "client": "WORKS",
+  "delay": 0,
+  "from": {
+    "email": "do_not_reply@holidayextras.com",
+    "name": "From Name"
+  },
+  "retries": 5,
+  "subject": "Subject",
+  "timezone": "UTC",
+  "to": {
+    "email": "customer@email.com",
+    "name": "Customer Name"
+  },
+  "type": "confirmation"
+}

--- a/test/fixtures/validOptions.json
+++ b/test/fixtures/validOptions.json
@@ -1,0 +1,20 @@
+{
+  "type": "confirmation",
+  "subject": "Subject",
+  "to": {
+    "name": "Customer Name",
+    "email": "customer@email.com"
+  },
+  "from": {
+    "name": "From Name",
+    "email": "do_not_reply@holidayextras.com"
+  },
+  "body": {
+    "html": {
+      "location": "https://example.com"
+    },
+    "text": {
+      "location": "https://example.com"
+    }
+  }
+}

--- a/test/pluginDispatchrTest.js
+++ b/test/pluginDispatchrTest.js
@@ -1,29 +1,28 @@
-/* jslint node: true */
+/*eslint no-unused-expressions:0 */
 'use strict';
 
 var chai = require( 'chai' );
 var chaiAsPromised = require( 'chai-as-promised' );
 chai.use( chaiAsPromised );
 chai.should();
+var sinon = require( 'sinon' );
+var _ = require( 'lodash' );
 
-
+var dispatchr = require( 'dispatchr-module' );
 var Hapi = require( 'hapi' );
 
 var server;
+
+// allow resources to be required safely
+function loadTestResource( resource ) {
+  return _.cloneDeep( require( './' + resource ) );
+}
 
 describe( 'pluginDispatchr', function() {
 
   before( function( done ) {
     // Need to start up a server
     server = new Hapi.Server();
-    server.methods.getConfig = function() {
-      return {
-        cache: {
-          host: '127.0.0.1',
-          port: '6379'
-        }
-      };
-    };
 
     // and then register this plugin to that server
     server.pack.register( require( '../lib/pluginDispatchr' ), function() {
@@ -31,14 +30,69 @@ describe( 'pluginDispatchr', function() {
     } );
   } );
 
-  describe( '.register()', function() {
+  describe( '#register', function() {
     it( 'should allow us to access the plugin off the hapi server', function( done ) {
       server.plugins[ 'plugin-dispatchr' ].should.not.equal( undefined );
       done();
     } );
   } );
 
-  describe( '.makeItSo()', function() {
+  describe( '#publishEmail', function() {
+
+    context( 'Validation', function() {
+
+      it( 'should fail when the options are missing required parameters', function() {
+        return server.plugins[ 'plugin-dispatchr' ].publishEmail( {} ).should.eventually.be.rejected.and.eventually.have.property( 'error' ).that.is.an.instanceof( TypeError );
+      } );
+
+    } );
+
+    context( 'Dispatchr module successful', function() {
+      var checkType;
+      var checkOptions;
+
+      before( function( done ) {
+        sinon.stub( dispatchr, 'publish', function( type, options, callback ) {
+          checkType = type;
+          checkOptions = options;
+          callback();
+        } );
+        done();
+      } );
+
+      it( 'should be call dispatchr-module with the correct parameters and resolve', function() {
+        return server.plugins[ 'plugin-dispatchr' ].publishEmail( loadTestResource( 'fixtures/validOptions' ) ).then( function() {
+          checkType.should.equal( 'email' );
+          checkOptions.should.deep.equal( loadTestResource( 'expected/validMergedOptions' ) );
+        } );
+      } );
+
+      after( function( done ) {
+        dispatchr.publish.restore();
+        done();
+      } );
+
+    } );
+
+    context( 'Dispatchr module errorred', function() {
+
+      before( function( done ) {
+        sinon.stub( dispatchr, 'publish', function( type, options, callback ) {
+          callback( 'error ');
+        } );
+        done();
+      } );
+
+      it( 'should pass back errors from dispatchr-module as a rejected promise', function() {
+        return server.plugins[ 'plugin-dispatchr' ].publishEmail( loadTestResource( 'fixtures/validOptions' ) ).should.be.rejected;
+      } );
+
+      after( function( done ) {
+        dispatchr.publish.restore();
+        done();
+      } );
+
+    } );
 
 
   } );


### PR DESCRIPTION
#### What are the links to relevant tickets?
https://hxshortbreaks.atlassian.net/browse/WEB-6036

#### What does this PR do?
This completes initial functionality that will 'publish' an email to the dispatchr queue.

#### What functional/unit tests does this PR have?
100% coverage

#### How should a developer review this?
Pull it down and run the tests. There is also a branch on the-works called dispatchr_test that will allow you to hit a temp endpoint

http://localhost:3000/temp/sendEmail/orderId/email%40domain.com (can't use @ here)

Before booting the works you need to download rabbitmq and follow the instructions for putting it on as a launch item (need to decide the long term solution to this).

You can view email messages being added here http://localhost:15672/#/queues/%2F/email

To process the queue you need to download, npm install and run grunt on the main dispatchr repo.

#### Any background context you want to provide?
We currently send emails through HXML but ATG doesn't have any code on HXML. Core have solved email sending with dispatchr so I thought I would see how simple it was to integrate into a plugin.

Turns out very simple so I have brought my hacked work up to coding standards on this repo.

The module prints out errors when it can't connect to rabbitmq, which then causes the code coverage report to break in shippable (basically console logs in the middle of xml isn't parseable) so I have removed that declaration there

#### Screenshots (if appropriate)


---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [x] I've updated documentation with any changes to procedures.
- [x] I've checked this work against the requirements of the Jira.
- [x] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.

#### Reviewer 1 @kevinhodges
- [x] I agree with the assumptions made in the quality checklist.
- [x] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!

#### Reviewer 2 @panicnot
- [x] I agree with the assumptions made in the quality checklist.
- [x] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!