### PR TITLE
Bump to make-up 6 and use Chai Expect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-dispatchr",
   "description": "A hapi plugin that wraps around around the dispatchr module to add email sends to the queue.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/holidayextras/plugin-dispatchr",
   "author": {
     "name": "Shortbreaks",
@@ -25,7 +25,7 @@
     "deployment-helpers": "git+ssh://git@github.com:holidayextras/deployment-helpers.git",
     "hapi": "6.0.2",
     "istanbul": "0.3.7",
-    "make-up": "5.3.1",
+    "make-up": "6.0.0",
     "mocha": "1.20.1",
     "sinon": "1.12.2"
   },

--- a/test/pluginDispatchrTest.js
+++ b/test/pluginDispatchrTest.js
@@ -2,9 +2,8 @@
 'use strict';
 
 var chai = require( 'chai' );
-var chaiAsPromised = require( 'chai-as-promised' );
-chai.use( chaiAsPromised );
-chai.should();
+chai.use( require( 'chai-as-promised' ) );
+var expect = chai.expect;
 var sinon = require( 'sinon' );
 var _ = require( 'lodash' );
 
@@ -32,7 +31,7 @@ describe( 'pluginDispatchr', function() {
 
   describe( '#register', function() {
     it( 'should allow us to access the plugin off the hapi server', function( done ) {
-      server.plugins[ 'plugin-dispatchr' ].should.not.equal( undefined );
+      expect( server.plugins[ 'plugin-dispatchr' ] ).to.not.equal( undefined );
       done();
     } );
   } );
@@ -42,7 +41,7 @@ describe( 'pluginDispatchr', function() {
     context( 'Validation', function() {
 
       it( 'should fail when the options are missing required parameters', function() {
-        return server.plugins[ 'plugin-dispatchr' ].publishEmail( {} ).should.eventually.be.rejected.and.eventually.have.property( 'error' ).that.is.an.instanceof( TypeError );
+        return expect( server.plugins[ 'plugin-dispatchr' ].publishEmail( {} ) ).to.eventually.be.rejected.and.eventually.have.property( 'error' ).that.is.an.instanceof( TypeError );
       } );
 
     } );
@@ -62,8 +61,8 @@ describe( 'pluginDispatchr', function() {
 
       it( 'should be call dispatchr-module with the correct parameters and resolve', function() {
         return server.plugins[ 'plugin-dispatchr' ].publishEmail( loadTestResource( 'fixtures/validOptions' ) ).then( function() {
-          checkType.should.equal( 'email' );
-          checkOptions.should.deep.equal( loadTestResource( 'expected/validMergedOptions' ) );
+          expect( checkType ).to.equal( 'email' );
+          expect( checkOptions ).to.deep.equal( loadTestResource( 'expected/validMergedOptions' ) );
         } );
       } );
 
@@ -84,7 +83,7 @@ describe( 'pluginDispatchr', function() {
       } );
 
       it( 'should pass back errors from dispatchr-module as a rejected promise', function() {
-        return server.plugins[ 'plugin-dispatchr' ].publishEmail( loadTestResource( 'fixtures/validOptions' ) ).should.be.rejected;
+        return expect( server.plugins[ 'plugin-dispatchr' ].publishEmail( loadTestResource( 'fixtures/validOptions' ) ) ).to.be.rejected;
       } );
 
       after( function( done ) {


### PR DESCRIPTION
#### What are the links to relevant tickets?
None - no changes to functionality, just bringing the repo up to some more recent standards.

#### What does this PR do?
Updates to latest make-up (6.0)

Swaps out the use of should to expect as per the current culture guidelines https://github.com/holidayextras/culture/blob/master/testing-standard.md

#### What functional/unit tests does this PR have?
Same as before, what were you expecting?

#### How should a developer review this?
Read through

#### Any background context you want to provide?


#### Screenshots (if appropriate)
---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [ ] I've updated documentation with any changes to procedures.
- [ ] I've checked this work against the requirements of the Jira.
- [x] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.

#### Reviewer 1 @kevinhodges
- [x] I agree with the assumptions made in the quality checklist.
- [x] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!

#### Reviewer 2 @t1gr0u
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!